### PR TITLE
Allow compilation for M1

### DIFF
--- a/ngransac/ngransac.cpp
+++ b/ngransac/ngransac.cpp
@@ -1,8 +1,8 @@
 #include <torch/torch.h>
 #include <opencv2/opencv.hpp>
-
+#if defined(_OPENMP)
 #include <omp.h>
-
+#endif
 #include <iostream>
 
 #include "thread_rand.h"
@@ -76,8 +76,12 @@ double find_essential_mat(
 	#pragma omp parallel for
 	for(int h = 0; h < hypCount; h++)
 	{
+#if defined(_OPENMP)
 		unsigned threadID = omp_get_thread_num();
+#else
 
+		unsigned threadID = 0;
+#endif
 		//sample a minimal set
 		std::vector<cv::Point2d> minSet1(cMin); // coordinates of image 1
 		std::vector<cv::Point2d> minSet2(cMin); // coordinates of image 2
@@ -316,7 +320,12 @@ double find_fundamental_mat(
 	#pragma omp parallel for
 	for(int h = 0; h < hypCount; h++)
 	{
+#if defined(_OPENMP)
 		unsigned threadID = omp_get_thread_num();
+#else
+
+		unsigned threadID = 0;
+#endif
 
 		//sample a minimal set
 		std::vector<cv::Point2d> minSet1(cMin);

--- a/ngransac/thread_rand.cpp
+++ b/ngransac/thread_rand.cpp
@@ -1,5 +1,7 @@
-#include "thread_rand.h"
+#if defined(_OPENMP)
 #include <omp.h>
+#endif
+#include "thread_rand.h"
 
 std::vector<std::mt19937> ThreadRand::generators;
 bool ThreadRand::initialised = false;
@@ -16,7 +18,11 @@ void ThreadRand::init(unsigned seed)
     {
 	if(!initialised)
 	{
+#if defined(_OPENMP)
 	    unsigned nThreads = omp_get_max_threads();
+#else
+	    unsigned nThreads = 1;
+#endif
 	    
 	    for(unsigned i = 0; i < nThreads; i++)
 	    {    
@@ -32,8 +38,11 @@ void ThreadRand::init(unsigned seed)
 int ThreadRand::irand(int min, int max, int tid)
 {
     std::uniform_int_distribution<int> dist(min, max);
-
+#if defined(_OPENMP)
     unsigned threadID = omp_get_thread_num();
+#else
+    unsigned threadID = 0;
+#endif
     if(tid >= 0) threadID = tid;
     
     if(!initialised) init();
@@ -45,7 +54,11 @@ double ThreadRand::drand(double min, double max, int tid)
 {
     std::uniform_real_distribution<double> dist(min, max);
     
+#if defined(_OPENMP)
     unsigned threadID = omp_get_thread_num();
+#else
+    unsigned threadID = 0;
+#endif
     if(tid >= 0) threadID = tid;
 
     if(!initialised) init();
@@ -57,7 +70,11 @@ double ThreadRand::dgauss(double mean, double stdDev, int tid)
 {
     std::normal_distribution<double> dist(mean, stdDev);
     
+#if defined(_OPENMP)
     unsigned threadID = omp_get_thread_num();
+#else
+    unsigned threadID = 0;
+#endif
     if(tid >= 0) threadID = tid;
 
     if(!initialised) init();

--- a/ngransac_demo.py
+++ b/ngransac_demo.py
@@ -59,9 +59,9 @@ else:
 	else:
 		print("Using SIFT.\n")
 	if opt.nfeatures > 0:
-		detector = cv2.SIFT_create(nfeatures=opt.nfeatures, contrastThreshold=1e-5)
+		detector = cv2.xfeatures2d.SIFT_create(nfeatures=opt.nfeatures, contrastThreshold=1e-5)
 	else:
-		detector = cv2.SIFT_create()
+		detector = cv2.xfeatures2d.SIFT_create()
 
 # loading neural guidence network
 model_file = opt.model
@@ -72,9 +72,8 @@ if len(model_file) == 0:
 	print(model_file)
 
 model = CNNet(opt.resblocks)
-device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
-model.load_state_dict(torch.load(model_file,map_location=torch.device('cpu')))
-model = model.to(device)
+model.load_state_dict(torch.load(model_file))
+model = model.cuda()
 model.eval()
 print("Successfully loaded model.")
 
@@ -141,7 +140,7 @@ pts1 = np.array([pts1])
 pts2 = np.array([pts2])
 
 ratios = np.array([ratios])
-ratios = np.expand_dims(ratios, 2).reshape( -1, 1,  1)
+ratios = np.expand_dims(ratios, 2)
 
 # ------------------------------------------------
 # fit fundamental or essential matrix using OPENCV
@@ -182,12 +181,12 @@ if opt.nosideinfo:
 	ratios = np.zeros(ratios.shape)
 
 # create data tensor of feature coordinates and matching ratios
-print (pts1.shape, pts2.shape, ratios.shape)
 correspondences = np.concatenate((pts1, pts2, ratios), axis=2)
+correspondences = np.transpose(correspondences)
 correspondences = torch.from_numpy(correspondences).float()
-correspondences = correspondences.permute(2, 0, 1).float()
+
 # predict neural guidance, i.e. RANSAC sampling probabilities
-log_probs = model(correspondences[None].to(device))[0] #zero-indexing creates and removes a dummy batch dimension
+log_probs = model(correspondences.unsqueeze(0).cuda())[0] #zero-indexing creates and removes a dummy batch dimension
 probs = torch.exp(log_probs).cpu()
 
 out_model = torch.zeros((3, 3)).float() # estimated model


### PR DESCRIPTION
Hi,

I made some (safe) changes to be able to run on Apple M1 laptop with recent pytorch. 
Specifically, M1 clang have problems with OpenMP (see https://stackoverflow.com/questions/66680002/clang-openmp-support-on-apple-m1) and does not have any cuda-available device.

So I guarded OpenMP imports with `#ifdef` and used `map_location` when loading pretrained weights.

User also have to comment-out this line from setup.py https://github.com/vislearn/ngransac/blob/master/ngransac/setup.py#L36 but that is easy and better not be included in commit, as the most people would like to enjoy OpenMP speed-up.